### PR TITLE
Revert "P3110: force builder to have vendor repos to compile"

### DIFF
--- a/p3110.mk
+++ b/p3110.mk
@@ -32,5 +32,5 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.consumerir.xml:system/etc/permissions/android.hardware.consumerir.xml
 
-# Use the non-open-source parts
-$(call inherit-product, vendor/samsung/p31xx/p3110-vendor.mk)
+# Use the non-open-source parts, if they're present
+$(call inherit-product-if-exists, vendor/samsung/p31xx/p3110-vendor.mk)


### PR DESCRIPTION
This reverts commit f8aefb2d4ab0804bf0a87d5f546207a150bfbf4d.

Change-Id: I09a289c0feaa5ae944308c8702f257b92ae66c7f